### PR TITLE
Remote ZIP handler

### DIFF
--- a/resource_sharing/repository_handler/__init__.py
+++ b/resource_sharing/repository_handler/__init__.py
@@ -3,3 +3,4 @@ from remote_git_handler import RemoteGitHandler
 from github_handler import GithubHandler
 from bitbucket_handler import BitBucketHandler
 from filesystem_handler import FileSystemHandler
+from remote_zip_handler import RemoteZipHandler

--- a/resource_sharing/repository_handler/base.py
+++ b/resource_sharing/repository_handler/base.py
@@ -14,6 +14,7 @@ import logging
 from PyQt4.QtCore import QTemporaryFile
 from qgis.core import QGis
 
+from ext_libs.giturlparse import validate as git_validate
 from resource_sharing.config import COLLECTION_NOT_INSTALLED_STATUS
 from resource_sharing.exception import MetadataError
 from resource_sharing.version_compare import isCompatible
@@ -91,6 +92,11 @@ class BaseRepositoryHandler(object):
         """Setter to the repository's URL."""
         self._url = url
         self._parsed_url = urlparse.urlparse(url)
+
+    @property
+    def is_git_repository(self):
+        """Flag if a repository is a git repository."""
+        return git_validate(self._url)
 
     @property
     def metadata(self):

--- a/resource_sharing/repository_handler/base.py
+++ b/resource_sharing/repository_handler/base.py
@@ -49,7 +49,7 @@ class BaseRepositoryHandler(object):
         """Constructor of the base class."""
         self._url = None
         self._metadata = None
-        self._url_parse_result = None
+        self._parsed_url = None
 
         # Call proper setters here
         self.url = url
@@ -90,7 +90,7 @@ class BaseRepositoryHandler(object):
     def url(self, url):
         """Setter to the repository's URL."""
         self._url = url
-        self._url_parse_result = urlparse.urlparse(url)
+        self._parsed_url = urlparse.urlparse(url)
 
     @property
     def metadata(self):

--- a/resource_sharing/repository_handler/filesystem_handler.py
+++ b/resource_sharing/repository_handler/filesystem_handler.py
@@ -19,10 +19,10 @@ class FileSystemHandler(BaseRepositoryHandler):
         """Constructor."""
         BaseRepositoryHandler.__init__(self, url)
 
-        self._path = self._url_parse_result.path
+        self._path = self._parsed_url.path
 
     def can_handle(self):
-        if self._url_parse_result.scheme == 'file':
+        if self._parsed_url.scheme == 'file':
             return True
 
     def fetch_metadata(self):

--- a/resource_sharing/repository_handler/filesystem_handler.py
+++ b/resource_sharing/repository_handler/filesystem_handler.py
@@ -22,8 +22,9 @@ class FileSystemHandler(BaseRepositoryHandler):
         self._path = self._parsed_url.path
 
     def can_handle(self):
-        if self._parsed_url.scheme == 'file':
-            return True
+        if not self.is_git_repository:
+            if self._parsed_url.scheme == 'file':
+                return True
 
     def fetch_metadata(self):
         """Fetch metadata file from the repository."""

--- a/resource_sharing/repository_handler/remote_zip_handler.py
+++ b/resource_sharing/repository_handler/remote_zip_handler.py
@@ -69,7 +69,7 @@ class RemoteZipHandler(BaseRepositoryHandler):
         zf.extractall(path=local_collection_path(id))
         return True, None
 
-    def preview_url(self, collection_name, filename):
-        image_path = 'collections/%s/preview/%s' % (collection_name, filename)
+    def preview_url(self, collection_name, file_path):
+        image_path = 'collections/%s/%s' % (collection_name, file_path)
         image_url = urlparse.urljoin(self.url, image_path)
         return image_url

--- a/resource_sharing/repository_handler/remote_zip_handler.py
+++ b/resource_sharing/repository_handler/remote_zip_handler.py
@@ -50,7 +50,8 @@ class RemoteZipHandler(BaseRepositoryHandler):
         :type register_name: unicode
         """
         # Download the zip first
-        zip_collection_url = urlparse.urljoin(self.url, 'collections', register_name)
+        collection_path = 'collections/%s.zip' % register_name
+        zip_collection_url = urlparse.urljoin(self.url, collection_path)
         network_manager = NetworkManager(zip_collection_url)
         status, description = network_manager.fetch()
 
@@ -68,6 +69,6 @@ class RemoteZipHandler(BaseRepositoryHandler):
         return True, None
 
     def preview_url(self, collection_name, filename):
-        image_url = urlparse.urljoin(
-            self.url, 'collections', collection_name, 'preview', filename)
+        image_path = 'collections/%s/preview/%s' % (collection_name, filename)
+        image_url = urlparse.urljoin(self.url, image_path)
         return image_url

--- a/resource_sharing/repository_handler/remote_zip_handler.py
+++ b/resource_sharing/repository_handler/remote_zip_handler.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+import logging
+import urlparse
+import requests
+from zipfile import ZipFile
+
+from PyQt4.QtCore import QTemporaryFile
+
+from resource_sharing.repository_handler.base import BaseRepositoryHandler
+from resource_sharing.utilities import local_collection_path
+from resource_sharing.network_manager import NetworkManager
+
+
+LOGGER = logging.getLogger('QGIS Resources Sharing')
+
+
+class RemoteZipHandler(BaseRepositoryHandler):
+    """Class to handle remote zip repository."""
+    IS_DISABLED = False
+
+    def __init__(self, url=None):
+        """Constructor."""
+        BaseRepositoryHandler.__init__(self, url)
+
+    def can_handle(self):
+        if self._parsed_url.scheme == 'http' or self._parsed_url.scheme == 'https':
+            return True
+
+    def fetch_metadata(self):
+        """Fetch metadata file from the url."""
+        # Download the metadata
+        metadata_url = urlparse.urljoin(self.url, self.METADATA_FILE)
+        network_manager = NetworkManager(metadata_url)
+        status, description = network_manager.fetch()
+        if status:
+            self.metadata = network_manager.content
+        return status, description
+
+    def download_collection(self, id, register_name):
+        """Download a collection given its ID.
+
+        For zip collection, we will download the zip, and extract the
+        collection to collections dir.
+
+        :param id: The ID of the collection.
+        :type id: str
+
+        :param register_name: The register name of the collection (the
+            section name of the collection)
+        :type register_name: unicode
+        """
+        # Download the zip first
+        zip_collection_url = urlparse.urljoin(self.url, 'collections', register_name)
+        network_manager = NetworkManager(zip_collection_url)
+        status, description = network_manager.fetch()
+
+        if not status:
+            return False, description
+
+        # Create the zip file
+        zip_file = QTemporaryFile()
+        if zip_file.open():
+            zip_file.write(network_manager.content)
+            zip_file.close()
+
+        zf = ZipFile(zip_file.fileName())
+        zf.extractall(path=local_collection_path(id))
+        return True, None
+
+    def preview_url(self, collection_name, filename):
+        image_url = urlparse.urljoin(
+            self.url, 'collections', collection_name, 'preview', filename)
+        return image_url

--- a/resource_sharing/repository_handler/remote_zip_handler.py
+++ b/resource_sharing/repository_handler/remote_zip_handler.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 import logging
 import urlparse
-import requests
 from zipfile import ZipFile
 
 from PyQt4.QtCore import QTemporaryFile
@@ -23,8 +22,10 @@ class RemoteZipHandler(BaseRepositoryHandler):
         BaseRepositoryHandler.__init__(self, url)
 
     def can_handle(self):
-        if self._parsed_url.scheme == 'http' or self._parsed_url.scheme == 'https':
-            return True
+        if not self.is_git_repository:
+            if self._parsed_url.scheme in ['http', 'https']:
+                return True
+        return False
 
     def fetch_metadata(self):
         """Fetch metadata file from the url."""


### PR DESCRIPTION
Hi @elpaso, this is working using zip handler. To use zip handler, you need to set the repo URI like this example:
Repo: ```http://localhost:63342/zip_data_example/```. Users need to put the metadata in this URI: ```http://localhost:63342/zip_data_example/metadata.ini``` and the collection in this URI ```http://localhost:63342/zip_data_example/collections/<collection_name>.zip```

It doesn't support custom collection URI yet and still using the old repository handlers (not refactoring it into metadata handler and collection handler)
